### PR TITLE
Report test coverage in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements.txt -r requirements-dev.txt
 
-      - name: Run tests
-        run: pytest -v
+      - name: Run tests with coverage
+        run: pytest -v --cov=agents --cov=utils --cov-report=term-missing --cov-report=xml --cov-fail-under=85
+
+      - name: Coverage summary
+        if: always() && matrix.python-version == '3.12'
+        run: |
+          echo "### Coverage" >> "$GITHUB_STEP_SUMMARY"
+          python -c "import xml.etree.ElementTree as ET; print(f\"Line coverage: {float(ET.parse('coverage.xml').getroot().get('line-rate'))*100:.1f}%\")" >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ Thumbs.db
 
 # Output
 output/*.docx
+
+# Coverage
+.coverage
+coverage.xml
+htmlcov/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 ruff>=0.15
+pytest-cov>=5


### PR DESCRIPTION
Measures test coverage on the matrix and enforces a floor.

What changed:
- pytest-cov added to requirements-dev.txt
- the test job runs pytest with coverage and fails below the threshold
- line coverage is written to the CI job summary
- coverage output files are git ignored

I used a CI threshold plus a job summary rather than a Codecov badge, so no external account is needed. A dynamic badge can be added later by connecting Codecov.

Closes #16