### PR TITLE
Run on Python 3.11 to 3.13 and support NumPy 2.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An AI-powered multi-agent system that transforms raw business data (CSV/Excel) into intelligence reports with embedded charts, statistical analysis, and actionable recommendations.
 
 ![CI](https://github.com/eugen-goebel/bi-data-analyst/actions/workflows/tests.yml/badge.svg)
-![Python](https://img.shields.io/badge/Python-3.10+-blue)
+![Python](https://img.shields.io/badge/Python-3.11+-blue)
 ![Tests](https://img.shields.io/badge/Tests-78_passed-brightgreen)
 ![pandas](https://img.shields.io/badge/pandas-2.0+-150458)
 ![matplotlib](https://img.shields.io/badge/matplotlib-3.7+-11557c)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ python-dotenv>=1.2.2
 pydantic>=2.13.3
 pandas>=2.0.0
 matplotlib>=3.7.0
-numpy>=1.24.0
+numpy>=2.0.0
 openpyxl>=3.1.0
 pytest>=9.0.3


### PR DESCRIPTION
NumPy 2.3 and newer requires Python 3.11+, which is why the NumPy 2.x bump failed CI on the 3.10 job.

What changed:
- test matrix moved from 3.10, 3.11, 3.12 to 3.11, 3.12, 3.13
- NumPy floor raised to 2.0
- Python badge updated to 3.11+

Tests pass locally on NumPy 2.4. This supersedes the failing Dependabot bump.

Closes #17