### PR TITLE
Add mypy type checking

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,14 +17,17 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install Ruff
-        run: pip install -r requirements-dev.txt
+      - name: Install dependencies
+        run: pip install -r requirements.txt -r requirements-dev.txt
 
       - name: Ruff lint
         run: ruff check .
 
       - name: Ruff format check
         run: ruff format --check .
+
+      - name: Type check with mypy
+        run: mypy
 
   test:
     runs-on: ubuntu-latest

--- a/agents/insight_agent.py
+++ b/agents/insight_agent.py
@@ -104,6 +104,8 @@ class InsightAgent:
             output_format=InsightResult,
         )
 
+        if response.parsed_output is None:
+            raise RuntimeError("The model response could not be parsed into an InsightResult")
         return response.parsed_output
 
     def _format_context(self, summary: DataSummary, patterns: PatternAnalysis) -> str:

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -9,9 +9,9 @@ import tempfile
 
 import anthropic
 
-from agents.data_loader import DataLoaderAgent
+from agents.data_loader import DataLoaderAgent, DataSummary
 from agents.insight_agent import InsightAgent, InsightResult
-from agents.pattern_agent import PatternAgent
+from agents.pattern_agent import PatternAgent, PatternAnalysis
 from agents.visualization_agent import VisualizationAgent
 from utils.csv_exporter import export_analysis_csv
 from utils.report_generator import generate_docx_report
@@ -42,8 +42,8 @@ class BIAnalysisOrchestrator:
         self._pattern_agent = PatternAgent()
         self._viz_agent = VisualizationAgent()
         self._insight_agent = InsightAgent(self.client, model=model)
-        self._last_summary = None
-        self._last_patterns = None
+        self._last_summary: DataSummary | None = None
+        self._last_patterns: PatternAnalysis | None = None
 
     def run(self, filepath: str, sheet_name: str | None = None) -> str:
         """

--- a/agents/pattern_agent.py
+++ b/agents/pattern_agent.py
@@ -152,7 +152,7 @@ class PatternAgent:
 
     def _detect_trends(self, df: pd.DataFrame, summary: DataSummary) -> list[TrendResult]:
         """Detect trends in numeric columns over time."""
-        trends = []
+        trends: list[TrendResult] = []
         numeric_cols = df.select_dtypes(include=[np.number]).columns.tolist()
         date_cols = df.select_dtypes(include=["datetime64"]).columns
 
@@ -175,6 +175,7 @@ class PatternAgent:
             change_pct = round(((last_val - first_val) / abs(first_val)) * 100, 1)
             cv = monthly[col].std() / monthly[col].mean() if monthly[col].mean() != 0 else 0
 
+            direction: Literal["increasing", "decreasing", "stable", "volatile"]
             if cv > 0.3:
                 direction = "volatile"
             elif change_pct > 10:
@@ -273,7 +274,7 @@ class PatternAgent:
 
     def _detect_seasonality(self, df: pd.DataFrame, summary: DataSummary) -> list[SeasonalPattern]:
         """Detect seasonal patterns in time-series data."""
-        patterns = []
+        patterns: list[SeasonalPattern] = []
         date_cols = df.select_dtypes(include=["datetime64"]).columns
         numeric_cols = df.select_dtypes(include=[np.number]).columns
 
@@ -410,6 +411,7 @@ class PatternAgent:
             share = (float(value) / total) * 100
             cumulative += share
 
+            cls: Literal["A", "B", "C"]
             if cumulative <= self.A_THRESHOLD_PCT or a_count == 0:
                 # Always include at least one A segment so a single dominant
                 # value is not pushed into B by floating-point noise.

--- a/agents/visualization_agent.py
+++ b/agents/visualization_agent.py
@@ -237,7 +237,7 @@ class VisualizationAgent:
             fig, ax = plt.subplots(figsize=(8, 6))
             fig.patch.set_facecolor(BG_COLOR)
 
-            wedges, texts, autotexts = ax.pie(
+            wedges, texts, autotexts = ax.pie(  # type: ignore[misc]
                 grouped.values,
                 labels=grouped.index,
                 autopct="%1.1f%%",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,14 @@ target-version = "py310"
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B"]
 ignore = ["E501"]
+
+[tool.mypy]
+files = ["agents", "utils", "main.py"]
+python_version = "3.11"
+check_untyped_defs = true
+no_implicit_optional = true
+warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+module = ["pandas.*"]
+ignore_missing_imports = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 ruff>=0.15
 pytest-cov>=5
+mypy>=2.0

--- a/utils/report_generator.py
+++ b/utils/report_generator.py
@@ -9,6 +9,7 @@ import os
 from datetime import datetime
 
 from docx import Document
+from docx.document import Document as DocxDocument
 from docx.enum.text import WD_ALIGN_PARAGRAPH
 from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
@@ -47,7 +48,7 @@ def _set_cell_background(cell, hex_color: str):
     tcPr.append(shd)
 
 
-def _add_heading(doc: Document, text: str, level: int = 1):
+def _add_heading(doc: DocxDocument, text: str, level: int = 1):
     """Add a styled section heading."""
     para = doc.add_heading(text, level=level)
     run = para.runs[0]
@@ -63,7 +64,7 @@ def _add_heading(doc: Document, text: str, level: int = 1):
     return para
 
 
-def _add_bullet_list(doc: Document, items: list[str], indent: int = 0):
+def _add_bullet_list(doc: DocxDocument, items: list[str], indent: int = 0):
     """Add a bulleted list of items."""
     for item in items:
         para = doc.add_paragraph(style="List Bullet")
@@ -72,7 +73,7 @@ def _add_bullet_list(doc: Document, items: list[str], indent: int = 0):
         run.font.size = Pt(10.5)
 
 
-def _add_horizontal_rule(doc: Document):
+def _add_horizontal_rule(doc: DocxDocument):
     """Add a thin horizontal divider."""
     para = doc.add_paragraph()
     pPr = para._p.get_or_add_pPr()
@@ -88,7 +89,7 @@ def _add_horizontal_rule(doc: Document):
     para.paragraph_format.space_after = Pt(6)
 
 
-def _add_chart(doc: Document, chart_dir: str, chart_config):
+def _add_chart(doc: DocxDocument, chart_dir: str, chart_config):
     """Embed a chart image with caption."""
     chart_path = os.path.join(chart_dir, chart_config.filename)
     if not os.path.exists(chart_path):
@@ -111,7 +112,7 @@ def _add_chart(doc: Document, chart_dir: str, chart_config):
 # ---------------------------------------------------------------------------
 
 
-def _build_cover_page(doc: Document, summary: DataSummary):
+def _build_cover_page(doc: DocxDocument, summary: DataSummary):
     """Create a styled cover page."""
     doc.add_paragraph()
     doc.add_paragraph()
@@ -164,7 +165,7 @@ def _build_cover_page(doc: Document, summary: DataSummary):
     doc.add_page_break()
 
 
-def _build_metrics_table(doc: Document, stats):
+def _build_metrics_table(doc: DocxDocument, stats):
     """Build a table of key numeric statistics."""
     headers = ["Metric", "Mean", "Median", "Std Dev", "Min", "Max"]
     table = doc.add_table(rows=1 + len(stats), cols=6)
@@ -210,7 +211,7 @@ def _build_metrics_table(doc: Document, stats):
                 run.font.bold = True
 
 
-def _build_recommendations_table(doc: Document, recommendations):
+def _build_recommendations_table(doc: DocxDocument, recommendations):
     """Build a color-coded recommendations table."""
     headers = ["Priority", "Recommendation", "Category", "Expected Impact"]
     table = doc.add_table(rows=1 + len(recommendations), cols=4)
@@ -280,7 +281,7 @@ def _build_recommendations_table(doc: Document, recommendations):
         run.font.italic = True
 
 
-def _build_abc_table(doc: Document, analysis):
+def _build_abc_table(doc: DocxDocument, analysis):
     """Render one ABC analysis as a contributor table."""
     para = doc.add_paragraph()
     run = para.add_run(
@@ -319,7 +320,7 @@ def _build_abc_table(doc: Document, analysis):
     doc.add_paragraph()
 
 
-def _build_outlier_table(doc: Document, outliers):
+def _build_outlier_table(doc: DocxDocument, outliers):
     """Build a table of detected outliers."""
     if not outliers:
         doc.add_paragraph("No significant outliers detected.")


### PR DESCRIPTION
Adds static type checking as a pilot for the portfolio.

What changed:
- mypy config in pyproject.toml (checks agents, utils and main.py)
- fixed all 44 findings: optional orchestrator state, missing list annotations, Literal types for trend direction and ABC classes, the real python-docx Document type in annotations, and a None guard on the parsed model output
- the CI lint job now runs mypy after Ruff

mypy reports no issues, Ruff is clean and all 109 tests pass.