### PR TITLE
Remove unused type ignore on ax.pie call

### DIFF
--- a/agents/visualization_agent.py
+++ b/agents/visualization_agent.py
@@ -237,7 +237,7 @@ class VisualizationAgent:
             fig, ax = plt.subplots(figsize=(8, 6))
             fig.patch.set_facecolor(BG_COLOR)
 
-            wedges, texts, autotexts = ax.pie(  # type: ignore[misc]
+            wedges, texts, autotexts = ax.pie(
                 grouped.values,
                 labels=grouped.index,
                 autopct="%1.1f%%",


### PR DESCRIPTION
Newer matplotlib type stubs resolve the `pie()` overload correctly, so mypy flags the `# type: ignore[misc]` on the `ax.pie` call as unused (`unused-ignore`) and fails the lint job. This surfaced on Dependabot PR #32 but affects main as well.

Removing the comment fixes lint for #32 and main.